### PR TITLE
아티스트별 가장 많이 들은 곡 표출 뷰 작성

### DIFF
--- a/music/tests.py
+++ b/music/tests.py
@@ -1,7 +1,12 @@
 import json
 
 from .models        import (
-    Artist
+    Artist,
+    Track,
+    Album,
+    ArtistTrack,
+    ArtistAlbum,
+    AlbumTrack
 )
 
 from django.test    import TestCase
@@ -45,4 +50,73 @@ class ArtistTest(TestCase):
     def test_artist_get_not_found(self):
         client = Client()
         response = client.get('/music/aritst?artist_id=84')
+        self.assertEqual(response.status_code, 404)
+
+class ArtistTopTrackTest(TestCase):
+
+    def setUp(self):
+        client = Client()
+        Artist.objects.create(
+            id   = 1,
+            name = 'Future',
+        )
+        Track.objects.create(
+            id          = 1,
+            name        = 'Baby Pluto',
+            time        = '00:03:30.000000',
+            music_url   = None,
+            is_master   = 0,
+            is_explicit = 0,
+        )
+
+        ArtistTrack.objects.create(artist_id = 1, track_id = 1)
+
+        Album.objects.create(
+            id = 1,
+            name = 'Eternal Atake',
+            thumbnail_url = 'https://resources.tidal.com/images/cd542e79/dce0/4809/9f3e/1c3cb2203436/320x320.jpg'
+        )
+
+        AlbumTrack.objects.create(album_id = 1, track_id = 1)
+
+    def test_artist_toptrack_get_success(self):
+        client = Client()
+        response = client.get('/music/artist/1/toptrack')
+        self.assertEqual(response.json(),
+            {
+                'tracks':[{
+                    'id'            : 1,
+                    'name'          : 'Baby Pluto',
+                    'time'          : '00:03:30',
+                    'music_url'     : None,
+                    'is_master'     : False,
+                    'is_explicit'   : False,
+                    'artist_info'   : [{
+                        'id'    : 1,
+                        'name'  : 'Future'
+                    }],
+                    'album_info'    : [{
+                        'id'            : 1,
+                        'name'          : 'Eternal Atake',
+                        'thumbnail_url' : 'https://resources.tidal.com/images/cd542e79/dce0/4809/9f3e/1c3cb2203436/320x320.jpg',
+                        }
+                    ]
+                }]
+            }
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_artist_toptrack_get_fail(self):
+        client = Client()
+        response = client.get('/music/artist/2/toptrack')
+        self.assertEqual(response.json(),
+            {
+               'message':'NO_TRACK'
+            }
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_artist_toptrack_get_not_found(self):
+        client = Client()
+        response = client.get('/music/aritst/toptrack?artist_id=84')
         self.assertEqual(response.status_code, 404)

--- a/music/urls.py
+++ b/music/urls.py
@@ -1,8 +1,10 @@
 from django.urls    import path
 from .views         import (
     ArtistDetailView,
+    ArtistTopTrackView,
 )
 
 urlpatterns = [
     path('/artist/<int:artist_id>', ArtistDetailView.as_view()),
+    path('/artist/<int:artist_id>/toptrack', ArtistTopTrackView.as_view()),
 ]


### PR DESCRIPTION
	1. 개인 아티스트의 곡을 들은 횟수 (count)를 기준으로 정렬하여 표출
	2. url은 music/artist/<int:artist_id>/toptrack

- [X] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [X] Wecode의 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [X] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [X] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
- [X] Git rebase와 squash를 했고 커밋 수가 하나 인것을 확인 했습니다.
- [X] 유닛 테스트를 구현 하였고 모든 유닛 테스트가 통과 된것을 확인 하였습니다.
